### PR TITLE
Update for compatibility with puppet/selinux

### DIFF
--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -1,4 +1,9 @@
 fixtures:
+  forge_modules:
+    yumrepo_core:
+      repo: "puppetlabs/yumrepo_core"
+      ref: "1.0.1"
+      puppet_version: ">= 6.0.0"
   repositories:
     app_modeling: "https://github.com/puppetlabs/puppetlabs-app_modeling.git"
     mysql: "https://github.com/puppetlabs/puppetlabs-mysql.git"

--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,8 @@ group :development, :unit_tests do
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 end
 group :system_tests do
-  gem 'beaker',       :git => 'https://github.com/ipcrm/beaker.git',
-                      :ref => 'a60391e0dc257b87ff372bbffd424d1c46e4b55d'
-  gem 'beaker-rspec', :git => 'https://github.com/hunner/beaker-rspec.git',
-                      :ref => '755b3bfc6f8d661ab8c11838997890acd7875ab1'
+  gem 'beaker'
+  gem 'beaker-rspec'
   gem 'serverspec'
   gem 'beaker-puppet_install_helper'
   gem 'master_manipulator'

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -35,7 +35,7 @@ define rgbank::load (
     if $::selinux == true {
       if ! defined(Selinux::Port[$port_name]) {
         selinux::port { $port_name:
-          context  => 'http_port_t',
+          seltype  => 'http_port_t',
           port     => $member['port'],
           protocol => 'tcp',
           before   => Haproxy::Listen["rgbank-${name}"],

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -44,7 +44,7 @@ define rgbank::web (
     if $::selinux == true {
       if (! defined(Selinux::Port["allow-httpd-${listen_port}"])) {
         selinux::port { "allow-httpd-${listen_port}":
-          context  => 'http_port_t',
+          seltype  => 'http_port_t',
           port     => $listen_port,
           protocol => 'tcp',
           before   => [Rgbank::Web::Base[$name]],

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "jfryman-selinux",
-      "version_requirement": ">= 0.4.0"
+      "name": "puppet-selinux",
+      "version_requirement": ">= 2.0.0"
     },
     {
       "name": "mayflower-php",


### PR DESCRIPTION
In order to use the rgbank module alongside newer modules in a
control-repo, it is necessary for rgbank to support a more modern
version of the selinux module.